### PR TITLE
Correct arch detect on apple m1 machines

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,9 @@ switch (process.arch) {
   case "arm":
     env.GOARCH = "arm"
     break
+  case "arm64":
+    env.GOARCH = "arm64"
+    break
 }
 
 module.exports = env


### PR DESCRIPTION
This fixes arch detection on apple silicon machines and allows m1 users to install `go-ipfs` without environment variable workarounds